### PR TITLE
Include Products.CMFCore package for Plone 4.1+compatibility

### DIFF
--- a/mr/migrator/browser/configure.zcml
+++ b/mr/migrator/browser/configure.zcml
@@ -5,6 +5,8 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="mr.migrator">
 
+    <include package="Products.CMFCore" />
+
     <!-- Plone UI -->
     <configure zcml:condition="installed plone.app.z3cform">
         <configure zcml:condition="installed plone.app.transmogrifier">


### PR DESCRIPTION
Following: http://plone.org/documentation/manual/upgrade-guide/version/upgrading-plone-4.0-to-4.1/updating-add-on-products-for-plone-4.1/changing-dependencies-from-plone-to-products.cmfplone
added include for Products.CMFCore ZCML for Plone 4.1+ compatibility.

Fixes Issue #7.
