### PR TITLE
Fix @@mr.migrator view for Plone 5. Fixes #15

### DIFF
--- a/mr/migrator/configure.zcml
+++ b/mr/migrator/configure.zcml
@@ -12,15 +12,10 @@
 
   <!-- BBB -->
   <include
-      zcml:condition="installed zope.app.component"
-      package="zope.app.component"
-      file="meta.zcml"
-      />
-  <include
-      zcml:condition="not-installed zope.app.component"
       package="zope.component"
       file="meta.zcml"
       />
+  <include package=".browser" />
 
   <genericsetup:registerProfile
       zcml:condition="installed Products.GenericSetup"

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,6 @@ try:
     # If we are using Python 2.5 or greater we can require configparser
     eval("1 if True else 2")  # http://stackoverflow.com/questions/446052
     install_requires.append('configparser')
-    install_requires.append('zope.app.component')  # BBB Only needed in
-    # Plone >= 4?
 except SyntaxError:
     # If we are using Python 2.4 or lower we cannot require configparser
     pass


### PR DESCRIPTION
by removing zope.app.component (which is deprecated and therefore pulls in parts of Zope 4 we don't want)

This is probably not backwards compatible and I'm not sure whether it's good to include the browser subpackage automatically, but it works for me.  I don't understand what this product needed zope.app.component for - but that functionality is probably now in zope.component.

Feedback appreciated